### PR TITLE
Update example for Toolbox 2.12.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,68 @@
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+# Clangd
+.clangd
+
+# CMSIS Solution files and folders not to be tracked
+# default directory of build artifacts
+**/out
+# directory containing intermediate files to be regenerated
+**/tmp
+# cbuild output files
+*.cbuild.yml
+*.cbuild-idx.yml
+*.cbuild-run.yml
+*.cbuild-set.yml
+*.cbuild-pack.yml
+

--- a/Hello.csolution.yml
+++ b/Hello.csolution.yml
@@ -10,6 +10,8 @@ solution:
     - compiler: AC6
     - compiler: GCC
 
+  compiler: AC6
+
   # List the packs that define the device and/or board.
   packs:
     - pack: ARM::CMSIS
@@ -30,45 +32,101 @@ solution:
 
     - type: CS310
       device: ARM::SSE-310-MPS3_FVP
+      target-set:
+        - set:
+          images:
+            - project-context: Hello.Debug
 
     - type: CS315
       device: ARM::SSE-315-FVP
+      target-set:
+        - set:
+          images:
+            - project-context: Hello.Debug
 
     - type: CS320
       device: ARM::SSE-320-FVP
+      target-set:
+        - set:
+          images:
+            - project-context: Hello.Debug
 
     - type: CM0plus
       device: ARM::CMSDK_CM0plus_VHT
+      target-set:
+        - set:
+          images:
+            - project-context: Hello.Debug
 
     - type: CM0
       device: ARM::CMSDK_CM0_VHT
+      target-set:
+        - set:
+          images:
+            - project-context: Hello.Debug
 
     - type: CM3
       device: ARM::CMSDK_CM3_VHT
+      target-set:
+        - set:
+          images:
+            - project-context: Hello.Debug
 
     - type: CM4
       device: ARM::CMSDK_CM4_VHT
+      target-set:
+        - set:
+          images:
+            - project-context: Hello.Debug
 
     - type: CM4_FP
       device: ARM::CMSDK_CM4_FP_VHT
+      target-set:
+        - set:
+          images:
+            - project-context: Hello.Debug
 
     - type: CM7
       device: ARM::CMSDK_CM7_VHT
+      target-set:
+        - set:
+          images:
+            - project-context: Hello.Debug
 
     - type: CM7_SP
       device: ARM::CMSDK_CM7_SP_VHT
+      target-set:
+        - set:
+          images:
+            - project-context: Hello.Debug
 
     - type: CM7_DP
       device: ARM::CMSDK_CM7_DP_VHT
+      target-set:
+        - set:
+          images:
+            - project-context: Hello.Debug
 
     - type: CM23
       device: ARM::IOTKit_CM23_VHT
+      target-set:
+        - set:
+          images:
+            - project-context: Hello.Debug
 
     - type: CM33
       device: ARM::IOTKit_CM33_VHT
+      target-set:
+        - set:
+          images:
+            - project-context: Hello.Debug
 
     - type: CM33_FP
       device: ARM::IOTKit_CM33_FP_VHT
+      target-set:
+        - set:
+          images:
+            - project-context: Hello.Debug
 
   # List of different build configurations.
   build-types:

--- a/hello.c
+++ b/hello.c
@@ -39,7 +39,7 @@ static void app_main_thread (void *argument) {
     printf ("Hello World %d\r\n", count);
     if (count >= 100) printf ("\x04");  // EOT (0x04) stops simulation
     count++;
-    osDelay (100);
+    osDelay (500);
   }
 }
 


### PR DESCRIPTION
- Added missing components in csolution.yml for Toolbox v2.12.0.
- The osDelay value in hello.c was increased so that the output could be seen in the terminal.