### PR TITLE
Set avh-fvp version to 11.29.27. a.o.

### DIFF
--- a/.github/test-matrix.json
+++ b/.github/test-matrix.json
@@ -17,7 +17,8 @@
     {"type": "CM33_FP", "model": "FVP_MPS2_Cortex-M33", "uart": "fvp_mps2.UART0"},
     {"type": "CS300", "model": "FVP_Corstone_SSE-300", "uart": "mps3_board.uart0"},
     {"type": "CS310", "model": "FVP_Corstone_SSE-310", "uart": "mps3_board.uart0"},
-    {"type": "CS315", "model": "FVP_Corstone_SSE-315", "uart": "mps4_board.uart0"}
+    {"type": "CS315", "model": "FVP_Corstone_SSE-315", "uart": "mps4_board.uart0"},
+    {"type": "CS320", "model": "FVP_Corstone_SSE-320", "uart": "mps4_board.uart0"}	
   ],
   "builds": ["Release", "Debug"]
 }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -10,7 +10,7 @@
         "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.9.0",
         "arm:compilers/arm/armclang": "^6.24.0",
         "arm:debuggers/arm/armdbg": "^6.5.0",
-        "arm:models/arm/avh-fvp": "^11.29.27",
+        "arm:models/arm/avh-fvp": "11.29.27",
         "arm:compilers/arm/arm-none-eabi-gcc": "^14.2.1",
         "arm:tools/kitware/cmake": "^3.31.5",
         "arm:tools/ninja-build/ninja": "^1.12.1"


### PR DESCRIPTION
Workaround to fix https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/488
- Set avh-fvp version to 11.29.27. 
- Added CS320 as target type together with FVP_Corstone_SSE-320 as model