### PR TITLE
Updated tool versions in vcpkg-configuration. a.o.

### DIFF
--- a/.github/workflows/hello-ci.yml
+++ b/.github/workflows/hello-ci.yml
@@ -56,6 +56,11 @@ jobs:
       - name: Activate Arm tool license
         uses: ARM-software/cmsis-actions/armlm@v1
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
       - name: Cache packs
         uses: actions/cache@v5
         with:

--- a/Hello.cbuild-pack.yml
+++ b/Hello.cbuild-pack.yml
@@ -12,7 +12,7 @@ cbuild-pack:
     - resolved-pack: ARM::SSE_315_BSP@1.0.0
       selected-by-pack:
         - ARM::SSE_315_BSP
-    - resolved-pack: ARM::SSE_320_BSP@1.0.0
+    - resolved-pack: ARM::SSE_320_BSP@1.1.0
       selected-by-pack:
         - ARM::SSE_320_BSP
     - resolved-pack: ARM::V2M_MPS3_SSE_300_BSP@1.5.0

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -12,7 +12,6 @@
         "arm:tools/ninja-build/ninja": "^1.13.2",
         "arm:compilers/arm/armclang": "^6.24.0",
         "arm:compilers/arm/arm-none-eabi-gcc": "^14.3.1",
-        "arm:debuggers/arm/armdbg": "^6.6.1",
         "arm:models/arm/avh-fvp": "11.31.28"
     }
 }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -13,6 +13,6 @@
         "arm:compilers/arm/armclang": "^6.24.0",
         "arm:compilers/arm/arm-none-eabi-gcc": "^14.3.1",
         "arm:debuggers/arm/armdbg": "^6.6.1",
-        "arm:models/arm/avh-fvp": "11.29.27"
+        "arm:models/arm/avh-fvp": "11.31.28"
     }
 }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -7,12 +7,12 @@
         }
     ],
     "requires": {
-        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.9.0",
-        "arm:compilers/arm/armclang": "^6.24.0",
-        "arm:debuggers/arm/armdbg": "^6.5.0",
-        "arm:models/arm/avh-fvp": "11.29.27",
-        "arm:compilers/arm/arm-none-eabi-gcc": "^14.2.1",
+        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.13.0",
         "arm:tools/kitware/cmake": "^3.31.5",
-        "arm:tools/ninja-build/ninja": "^1.12.1"
+        "arm:tools/ninja-build/ninja": "^1.13.2",
+        "arm:compilers/arm/armclang": "^6.24.0",
+        "arm:compilers/arm/arm-none-eabi-gcc": "^14.3.1",
+        "arm:debuggers/arm/armdbg": "^6.6.1",
+        "arm:models/arm/avh-fvp": "11.29.27"
     }
 }


### PR DESCRIPTION
Addressed: https://github.com/Arm-Examples/AVH-Hello/issues/16
- Updated tool versions in vcpkg-configuration. AVH-FVP has been set to fix version 11.29.27. 
- Set SSE_320_BSP to version 1.1.0. 
- Added Python configuration action.